### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name"        : "LibZip",
+  "license"     : "MIT",
   "version"     : "*",
   "perl"        : "6.c",
   "description" : "Perl 6 bindings for libzip",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license